### PR TITLE
Implement balancer algorithm

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -16,11 +16,13 @@ func main() {
 	client.Timeout = 10 * time.Second
 
 	for range time.Tick(1 * time.Second) {
-		resp, err := client.Get(fmt.Sprintf("%s/api/v1/some-data", *target))
-		if err == nil {
-			log.Printf("response %d", resp.StatusCode)
-		} else {
-			log.Printf("error %s", err)
-		}
+		go func() {
+			resp, err := client.Get(fmt.Sprintf("%s/api/v1/some-data", *target))
+			if err == nil {
+				log.Printf("response %d", resp.StatusCode)
+			} else {
+				log.Printf("error %s", err)
+			}
+		}()
 	}
 }

--- a/cmd/lb/balancer.go
+++ b/cmd/lb/balancer.go
@@ -13,20 +13,27 @@ import (
 	"github.com/roman-mazur/design-practice-2-template/signal"
 )
 
+// Some as env variables?
 var (
-	port = flag.Int("port", 8090, "load balancer port")
-	timeoutSec = flag.Int("timeout-sec", 3, "request timeout time in seconds")
-	https = flag.Bool("https", false, "whether backends support HTTPs")
+	port       = flag.Int("port", 8090, "load balancer port")
+	timeoutSec = flag.Int("timeout-sec", 10, "request timeout time in seconds")
+	https      = flag.Bool("https", false, "whether backends support HTTPs")
 
 	traceEnabled = flag.Bool("trace", false, "whether to include tracing information into responses")
 )
 
+// Public?
+type server struct {
+	Url           string
+	ConnectionCnt int
+}
+
 var (
-	timeout = time.Duration(*timeoutSec) * time.Second
-	serversPool = []string{
-		"server1:8080",
-		"server2:8080",
-		"server3:8080",
+	timeout     = time.Duration(*timeoutSec) * time.Second
+	serversPool = []server{
+		{Url: "server1:8080"},
+		{Url: "server2:8080"},
+		{Url: "server3:8080"},
 	}
 )
 
@@ -51,6 +58,7 @@ func health(dst string) bool {
 	return true
 }
 
+// Method on Server?
 func forward(dst string, rw http.ResponseWriter, r *http.Request) error {
 	ctx, _ := context.WithTimeout(r.Context(), timeout)
 	fwdRequest := r.Clone(ctx)
@@ -84,6 +92,17 @@ func forward(dst string, rw http.ResponseWriter, r *http.Request) error {
 	}
 }
 
+// Pass only healthy ones?
+func Balance(pool []server) int {
+	min := 0
+	for i := 1; i < len(pool); i++ {
+		if pool[i].ConnectionCnt < pool[min].ConnectionCnt {
+			min = i
+		}
+	}
+	return min
+}
+
 func main() {
 	flag.Parse()
 
@@ -92,14 +111,17 @@ func main() {
 		server := server
 		go func() {
 			for range time.Tick(10 * time.Second) {
-				log.Println(server, health(server))
+				log.Println(server, health(server.Url))
 			}
 		}()
 	}
 
 	frontend := httptools.CreateServer(*port, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		// TODO: Рееалізуйте свій алгоритм балансувальника.
-		forward(serversPool[0], rw, r)
+		i := Balance(serversPool)
+		//Lock?
+		serversPool[i].ConnectionCnt++
+		forward(serversPool[i].Url, rw, r)
+		serversPool[i].ConnectionCnt--
 	}))
 
 	log.Println("Starting load balancer...")

--- a/cmd/lb/balancer.go
+++ b/cmd/lb/balancer.go
@@ -178,7 +178,10 @@ func (b *Balancer) Handle(rw http.ResponseWriter, r *http.Request) {
 	if min != nil {
 		min.Forward(rw, r)
 	} else {
-
+		error := "Request handling error: all servers are out of reach"
+		log.Println(error)
+		rw.WriteHeader(http.StatusServiceUnavailable)
+		rw.Write([]byte(error))
 	}
 }
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -13,7 +13,7 @@ import (
 
 var port = flag.Int("port", 8080, "server port")
 var delay = flag.Int("delay-sec", 0, "response delay in seconds")
-var healthFailure = flag.Bool("health", true, "whether the server is healthy")
+var healthFailure = flag.Bool("health", false, "whether the server is healthy")
 
 func main() {
 	flag.Parse()

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -33,7 +32,6 @@ func main() {
 	report := make(Report)
 
 	h.HandleFunc("/api/v1/some-data", func(rw http.ResponseWriter, r *http.Request) {
-		fmt.Println("Start...")
 		if *delay > 0 && *delay < 300 {
 			time.Sleep(time.Duration(*delay) * time.Second)
 		}
@@ -45,7 +43,6 @@ func main() {
 		_ = json.NewEncoder(rw).Encode([]string{
 			"1", "2",
 		})
-		fmt.Println("Stop...")
 	})
 
 	h.Handle("/report", report)


### PR DESCRIPTION
You can check it either with docker-compose (boring, only one server will handle requests with 1 second interval of requests) or locally, running the balancer and all servers with appropriate flags. Alternatively, you can set these flags in docker-compose.yml
For balancer:
--servers=localhost:8080,server2:8080,localhost:8082 (comma separated list of server URLs)
--timeout=10 (request timeout time in seconds)
For server:
--delay-sec=3 (response delay in seconds)
--health=false (if server is healthy)

Loads of mess related to concurrency, I promise, it works and it must be this way